### PR TITLE
Add redcap_version attribute to Project

### DIFF
--- a/redcap/request.py
+++ b/redcap/request.py
@@ -84,7 +84,9 @@ class RCRequest(object):
             'exp_fem': (['format'], 'formEventMapping',
                 'Exporting form-event mappings but content != formEventMapping'),
             'exp_user': (['format'], 'user',
-                'Exporting users but content is not user')
+		'Exporting users but content is not user'),
+	    'version': (['format'], 'version',
+		'Requesting version but content != version')
         }
         extra, req_content, err_msg = valid_data[self.type]
         required.extend(extra)
@@ -127,6 +129,8 @@ class RCRequest(object):
         if self.type == 'exp_file':
             # don't use the decoded r.text
             return r.content
+	elif self.type == 'version':
+	    return r.content
         else:
             if self.fmt == 'json':
                 content = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==1.2.1
 nose==1.2.1
 numpydoc==0.4
+semantic-version==2.3.1
 requests>=1.1.0
 wheel==0.22.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ def get_version():
         exec(f.read())
         return VERSION
 
-required = ['requests>=1.0.0']
+required = [
+    'requests>=1.0.0',
+    'semantic-version==2.3.1'
+]
 
 if __name__ == '__main__':
     if os.path.exists('MANIFEST'):

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -2,6 +2,7 @@
 
 import unittest
 from redcap import Project, RedcapError
+import semantic_version
 
 skip_pd = False
 try:
@@ -292,3 +293,7 @@ class ProjectTests(unittest.TestCase):
         import_mdy = import_factory('12/31/2000')
         response = self.reg_proj.import_records(import_mdy, date_format='MDY')
         self.assertEqual(response['count'], 1)
+
+    def test_get_version(self):
+	"""Testing retrieval of REDCap version associated with Project"""
+	self.assertTrue(isinstance(semantic_version.Version('1.0.0'), type(self.long_proj.redcap_version)))


### PR DESCRIPTION
On Project initialization PyCap will attempt to determine the REDCap version that the project is associated with. Fixes #43.