### PR TITLE
Issue 46

### DIFF
--- a/docs/deep.rst
+++ b/docs/deep.rst
@@ -44,6 +44,7 @@ When creating a ``Project`` object, PyCap goes ahead and makes some useful API c
 * ``events``: Unique event names (longitudinal projects)
 * ``arm_nums``: Unique arm numbers (longitudinal projects)
 * ``arm_names``: Unique arm names (longitudinal projects)
+* ``redcap_version``: version of REDCap the project is associated with.
 
 For non-longitudinal projects, ``events``, ``arm_nums``, and ``arm_names`` are empty tuples.
 
@@ -110,6 +111,9 @@ Finally, you can tweak the how the data is labeled or formatted::
     # quickly make a pandas.DataFrame
     data_frame = project.export_records(format='df')
     other_df = project.export_records(format='df', df_kwargs={'index_col': project.field_names[1]})
+
+    # export checkbox field labels as values (necessary in REDCap >= 6.0 to retrieve checkbox labels)
+    data = project.export_records(raw_or_label='label', export_checkbox_labels=True)  # note you will still have to set raw_or_label to `label`
 
 When you request a ``DataFrame``, PyCap exports the data as csv and passes it to the ``pandas.read_csv`` function. The ``df_kwargs`` dict can be used to guide the conversion from csv to ``DataFrame``.
 

--- a/redcap/project.py
+++ b/redcap/project.py
@@ -214,7 +214,8 @@ class Project(object):
     def export_records(self, records=None, fields=None, forms=None,
             events=None, raw_or_label='raw', event_name='label',
             format='json', export_survey_fields=False,
-            export_data_access_groups=False, df_kwargs=None):
+            export_data_access_groups=False, df_kwargs=None,
+            export_checkbox_labels=False):
         """
         Export data from the REDCap project.
 
@@ -261,6 +262,9 @@ class Project(object):
             Passed to ``pandas.read_csv`` to control construction of
             returned DataFrame.
             by default, ``{'index_col': self.def_field}``
+        export_checkbox_labels : (``False``), ``True``
+            specify whether to export checkbox values as their label on
+            export.
 
         Returns
         -------
@@ -275,9 +279,10 @@ class Project(object):
         pl = self.__basepl('record', format=ret_format)
         keys_to_add = (records, fields, forms, events,
                        raw_or_label, event_name, export_survey_fields,
-                       export_data_access_groups)
+                       export_data_access_groups, export_checkbox_labels)
         str_keys = ('records', 'fields', 'forms', 'events', 'rawOrLabel',
-                    'eventName', 'exportSurveyFields', 'exportDataAccessGroups')
+                    'eventName', 'exportSurveyFields', 'exportDataAccessGroups',
+                    'exportCheckboxLabel')
         for key, data in zip(str_keys, keys_to_add):
             if data:
                 #  Make a url-ok string

--- a/redcap/request.py
+++ b/redcap/request.py
@@ -84,9 +84,9 @@ class RCRequest(object):
             'exp_fem': (['format'], 'formEventMapping',
                 'Exporting form-event mappings but content != formEventMapping'),
             'exp_user': (['format'], 'user',
-		'Exporting users but content is not user'),
-	    'version': (['format'], 'version',
-		'Requesting version but content != version')
+                'Exporting users but content is not user'),
+                'version': (['format'], 'version',
+                'Requesting version but content != version')
         }
         extra, req_content, err_msg = valid_data[self.type]
         required.extend(extra)
@@ -129,8 +129,8 @@ class RCRequest(object):
         if self.type == 'exp_file':
             # don't use the decoded r.text
             return r.content
-	elif self.type == 'version':
-	    return r.content
+        elif self.type == 'version':
+            return r.content
         else:
             if self.fmt == 'json':
                 content = {}

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -295,5 +295,14 @@ class ProjectTests(unittest.TestCase):
         self.assertEqual(response['count'], 1)
 
     def test_get_version(self):
-	"""Testing retrieval of REDCap version associated with Project"""
-	self.assertTrue(isinstance(semantic_version.Version('1.0.0'), type(self.long_proj.redcap_version)))
+        """Testing retrieval of REDCap version associated with Project"""
+        self.assertTrue(isinstance(semantic_version.Version('1.0.0'), type(self.long_proj.redcap_version)))
+
+    def test_export_checkbox_labels(self):
+        """Testing the export of checkbox labels as field values"""
+        self.assertEqual(
+            self.reg_proj.export_records(
+                raw_or_label='label',
+                export_checkbox_labels=True)[0]['matcheck1___1'],
+                'Foo'
+        )


### PR DESCRIPTION
In REDCap >= 6.x it is necessary to include the exportCheckboxLabel parameter in the export records call in order to retrieve the labels for checkbox fields. Prior to 6.x this could be achieved simply by setting rawOrLabel to true. Its important to note that in order for checkbox labels to be exported as values you will still have to set raw_or_label to true in calls to export_records. Fixes #46.