### PR TITLE
Fixes backfill issue when def_field included in fields

### DIFF
--- a/redcap/project.py
+++ b/redcap/project.py
@@ -362,6 +362,8 @@ class Project(object):
             new_fields.append(self.def_field)
         if not fields:
             new_fields = self.field_names
+        else:
+            new_fields = list(fields)
         return new_fields
 
     def filter(self, query, output_fields=None):

--- a/redcap/project.py
+++ b/redcap/project.py
@@ -357,10 +357,10 @@ class Project(object):
         """
         if forms and not fields:
             new_fields = [self.def_field]
-        if fields and self.def_field not in fields:
+        elif fields and self.def_field not in fields:
             new_fields = list(fields)
             new_fields.append(self.def_field)
-        if not fields:
+        elif not fields:
             new_fields = self.field_names
         else:
             new_fields = list(fields)


### PR DESCRIPTION
This fixes an issue in Project.backfill_fields where:

- no form is specified
- fields are specified
- self.def_field is in the fields list

Which leads to `new_fields` being referenced before assignment. 

This fix will set new_fields = list(fields)